### PR TITLE
Add ContentType and ContentEncoding

### DIFF
--- a/azureiothub.js
+++ b/azureiothub.js
@@ -35,6 +35,8 @@ module.exports = function (RED) {
         node.log('Sending Message to Azure IoT Hub :\n   Payload: ' + JSON.stringify(data));
         // Create a message and send it to the IoT Hub every second
         var message = new Message(JSON.stringify(data));
+        message.contentType = "application/json";
+        message.contentEncoding = "utf-8";
         client.sendEvent(message, function (err, res) {
             if (err) {
                 node.error('Error while trying to send message:' + err.toString());


### PR DESCRIPTION
Add ContentType and ContentEncoding to IoT Hub message to allow for pulling of data to not be Base64 encoding

From MS documentation:
https://learn.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-messages-construct

"Each IoT Hub protocol provides a message content type property which is respected when routing data to custom endpoints. To have your data properly handled at the destination (for example, JSON being treated as a parsable string instead of Base64 encoded binary data), you must provide the appropriate content type and charset for the message."